### PR TITLE
Update the Übercharge label

### DIFF
--- a/_lionhud/resource/ui/hudmediccharge.res
+++ b/_lionhud/resource/ui/hudmediccharge.res
@@ -92,7 +92,7 @@
 		"visible"		"1"
 		"enabled"		"1"
 		"tabPosition"	"0"
-		"labelText"		"UBERCHARGE"
+		"labelText"		"ÜBERCHARGE"
 		"textAlignment"	"west"
 		"dulltext"		"0"
 		"brighttext"	"0"

--- a/_lionhud/resource/ui/hudmediccharge.res
+++ b/_lionhud/resource/ui/hudmediccharge.res
@@ -114,7 +114,7 @@
 		"visible"		"1"
 		"enabled"		"1"
 		"tabPosition"	"0"
-		"labelText"		"UBERCHARGE"
+		"labelText"		"ÜBERCHARGE"
 		"textAlignment"	"west"
 		"dulltext"		"0"
 		"brighttext"	"0"


### PR DESCRIPTION
As a medic main it was kinda bugging me that the Übercharge label doesn't have the Umlaut on the letter "U".